### PR TITLE
Make subst highlighting visible against black background

### DIFF
--- a/views/style.scss
+++ b/views/style.scss
@@ -99,6 +99,7 @@ code.hljs {
   padding-left: 1rem;
 
   .hljs-string { color: $green; }
+  .hljs-subst { color: $yellow; }
   .hljs-constant { color: $blue; }
   .hljs-symbol { color: $cyan; }
   .hljs-keyword { color: $yellow; }


### PR DESCRIPTION
Highlight for the highlight.js class `.hljs-subst` is not overridden to be visible against a black background. This will change it to yellow, which will show up. Resolves #6 
